### PR TITLE
Support API 30

### DIFF
--- a/heifconverter/build.gradle
+++ b/heifconverter/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/heifconverter/src/main/java/linc/com/heifconverter/HeifConverter.kt
+++ b/heifconverter/src/main/java/linc/com/heifconverter/HeifConverter.kt
@@ -135,13 +135,13 @@ object HeifConverter{
                 bitmap = when (fromDataType) {
                     InputDataType.FILE -> {
                         when(Build.VERSION.SDK_INT) {
-                            Build.VERSION_CODES.Q -> BitmapFactory.decodeFile(pathToHeicFile)
+                            Build.VERSION_CODES.Q, Build.VERSION_CODES.R -> BitmapFactory.decodeFile(pathToHeicFile)
                             else -> HeifReader.decodeFile(pathToHeicFile)
                         }
                     }
                     InputDataType.URL -> {
                         when(Build.VERSION.SDK_INT) {
-                            Build.VERSION_CODES.Q -> {
+                            Build.VERSION_CODES.Q, Build.VERSION_CODES.R -> {
                                 // Download image
                                 val url = URL(url)
                                 val connection = url
@@ -156,19 +156,19 @@ object HeifConverter{
                     }
                     InputDataType.RESOURCES -> {
                         when(Build.VERSION.SDK_INT) {
-                            Build.VERSION_CODES.Q -> BitmapFactory.decodeResource(context.resources, resId!!)
+                            Build.VERSION_CODES.Q, Build.VERSION_CODES.R -> BitmapFactory.decodeResource(context.resources, resId!!)
                             else -> HeifReader.decodeResource(context.resources, resId!!)
                         }
                     }
                     InputDataType.INPUT_STREAM -> {
                         when(Build.VERSION.SDK_INT) {
-                            Build.VERSION_CODES.Q -> BitmapFactory.decodeStream(inputStream!!)
+                            Build.VERSION_CODES.Q, Build.VERSION_CODES.R -> BitmapFactory.decodeStream(inputStream!!)
                             else -> HeifReader.decodeStream(inputStream!!)
                         }
                     }
                     InputDataType.BYTE_ARRAY -> {
                         when(Build.VERSION.SDK_INT) {
-                            Build.VERSION_CODES.Q -> BitmapFactory.decodeByteArray(
+                            Build.VERSION_CODES.Q, Build.VERSION_CODES.R -> BitmapFactory.decodeByteArray(
                                 byteArray!!,
                                 0,
                                 byteArray!!.size,


### PR DESCRIPTION
This will allow users with API 30 (Android 11) to not default to HeifReader and instead to native implementation if available