### PR TITLE
Feature: Safer coroutines & less leaky Context

### DIFF
--- a/heifconverter/build.gradle
+++ b/heifconverter/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
     // Coroutines
     def coroutines_version = "1.6.2"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
     // Testing

--- a/heifconverter/src/main/java/linc/com/heifconverter/HeifConverter.kt
+++ b/heifconverter/src/main/java/linc/com/heifconverter/HeifConverter.kt
@@ -231,7 +231,9 @@ class HeifConverter internal constructor(private val context: Context) {
     }
 
     private fun useFormat(format: String) = when(format) {
-        WEBP -> Bitmap.CompressFormat.WEBP
+        WEBP ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) Bitmap.CompressFormat.WEBP_LOSSY
+            else @Suppress("DEPRECATION") Bitmap.CompressFormat.WEBP
         PNG -> Bitmap.CompressFormat.PNG
         else -> Bitmap.CompressFormat.JPEG
     }

--- a/heifconverter/src/main/java/linc/com/heifconverter/HeifConverter.kt
+++ b/heifconverter/src/main/java/linc/com/heifconverter/HeifConverter.kt
@@ -24,9 +24,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 
-object HeifConverter{
-
-    private lateinit var context: Context
+class HeifConverter internal constructor(private val context: Context) {
 
     private var pathToHeicFile: String? = null
     private var url: String? = null
@@ -42,11 +40,10 @@ object HeifConverter{
 
     private var fromDataType = InputDataType.NONE
 
-    fun useContext(context: Context) : HeifConverter {
-        this.context = context
-        HeifReader.initialize(HeifConverter.context)
+    private val heifReader = HeifReader(context)
+
+    init {
         initDefaultValues()
-        return this
     }
 
     fun fromFile(pathToFile: String) : HeifConverter {
@@ -147,7 +144,7 @@ object HeifConverter{
                     InputDataType.FILE -> {
                         when {
                             Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> BitmapFactory.decodeFile(pathToHeicFile)
-                            else -> HeifReader.decodeFile(pathToHeicFile)
+                            else -> heifReader.decodeFile(pathToHeicFile)
                         }
                     }
                     InputDataType.URL -> {
@@ -162,19 +159,19 @@ object HeifConverter{
                                 val input: InputStream = connection.inputStream
                                 BitmapFactory.decodeStream(input)
                             }
-                            else -> HeifReader.decodeUrl(url!!)
+                            else -> heifReader.decodeUrl(url!!)
                         }
                     }
                     InputDataType.RESOURCES -> {
                         when {
                             Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> BitmapFactory.decodeResource(context.resources, resId!!)
-                            else -> HeifReader.decodeResource(context.resources, resId!!)
+                            else -> heifReader.decodeResource(context.resources, resId!!)
                         }
                     }
                     InputDataType.INPUT_STREAM -> {
                         when {
                             Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> BitmapFactory.decodeStream(inputStream!!)
-                            else -> HeifReader.decodeStream(inputStream!!)
+                            else -> heifReader.decodeStream(inputStream!!)
                         }
                     }
                     InputDataType.BYTE_ARRAY -> {
@@ -187,7 +184,7 @@ object HeifConverter{
                                     inJustDecodeBounds = true
                                 }
                             )
-                            else -> HeifReader.decodeByteArray(byteArray!!)
+                            else -> heifReader.decodeByteArray(byteArray!!)
                         }
                     }
                     else -> throw IllegalStateException("You forget to pass input type: File, Url etc. Use such functions: fromFile(. . .) etc.")
@@ -249,4 +246,8 @@ object HeifConverter{
         BYTE_ARRAY, NONE
     }
 
+    companion object {
+
+        fun useContext(context: Context) = HeifConverter(context)
+    }
 }

--- a/heifconverter/src/main/java/linc/com/heifconverter/HeifConverter.kt
+++ b/heifconverter/src/main/java/linc/com/heifconverter/HeifConverter.kt
@@ -6,6 +6,7 @@ import android.graphics.BitmapFactory
 import android.os.Build
 import android.os.Environment
 import androidx.core.content.ContextCompat.getExternalFilesDirs
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -198,6 +199,8 @@ class HeifConverter internal constructor(private val context: Context) {
                 }
                 result[Key.IMAGE_PATH] = dest?.path
                     ?: "You set saveResultImage(false). If you want to save file - pass true"
+            } catch (cancellation: CancellationException) {
+                throw cancellation
             } catch (e : Exception) {
                 e.printStackTrace()
             } finally {

--- a/heifconverter/src/main/java/linc/com/heifconverter/HeifReader.kt
+++ b/heifconverter/src/main/java/linc/com/heifconverter/HeifReader.kt
@@ -35,25 +35,14 @@ import kotlin.coroutines.CoroutineContext
  *
  * Create Bitmap object from HEIF file, byte-array, stream, etc.
  */
-internal object HeifReader {
-    private const val TAG = "HeifReader"
+internal class HeifReader(context: Context) {
 
-    /**
-     * input data size limitation for safety.
-     */
-    private const val LIMIT_FILESIZE = 20 * 1024 * 1024 // 20[MB]
-        .toLong()
     private var mRenderScript: RenderScript? = null
     private var mCacheDir: File? = null
     private var mDecoderName: String? = null
     private var mDecoderSupportedSize: Size? = null
 
-    /**
-     * Initialize HeifReader module.
-     *
-     * @param context Context.
-     */
-    fun initialize(context: Context) {
+    init {
         mRenderScript = RenderScript.create(context)
         mCacheDir = context.cacheDir
 
@@ -556,6 +545,16 @@ internal object HeifReader {
         var length = 0
     }
 
-    private class FormatFallbackException internal constructor(ex: Throwable?) :
-        Exception(ex)
+    private class FormatFallbackException internal constructor(ex: Throwable?) : Exception(ex)
+
+    companion object {
+
+        private const val TAG = "HeifReader"
+
+        /**
+         * input data size limitation for safety.
+         */
+        private const val LIMIT_FILESIZE = 20 * 1024 * 1024 // 20[MB]
+            .toLong()
+    }
 }


### PR DESCRIPTION
## Reasoning

This PR aims to make the library a bit safer to use in terms of memory leaks, and coroutine usage.

The diff is messy because I moved the logic from `convert` to `convertBlocking`.

### Object -> Context

Currently both `HeifConverter` and `HeifReader` are static `objects` that get initialized with a `Context` object which never gets freed. This is a real easy way to leak an `Activity` or other context object.

In order to not introduce any breaking changes `HeifConverter` has an `internal constructor` and a `companion object` was created to hold the `useContext(context: Context)` function.

### Coroutines

Currently when `convert {}` is invoke a coroutine is launched in a constructed `CoroutineScope`. This is fine, but if the consumer wished to create unit tests or provide their own custom scope they are now able to.

I have also changed it so `convert()` now returns a reference to the coroutine via a `Job`. Which can then be cancelled by the consumer. The logic has also been moved from `convert()` to `convertBlocking()` so that the coroutine gets launched in the current scope instead of creating a new one.

In the conversion `try {} catch()` any `CancellationExceptions` are now rethrown so that it supports [cooperative cancellations](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative)

### Misc

Looks like `Bitmap.CompressFormat.WEBP` is deprecated in Android R. So it has now been replaced with `Bitmap.CompressFormat.WEBP_LOSSY` for R and above, while the older versions continue to get the original.

Since the library now exposes `Job` and `CoroutineScope`, the dependency on coroutines had to be changed to `api ""` so that there would be no breaking changes and the consumer wouldn't have to add the library themselves.